### PR TITLE
Maya bioin 1876 many variants

### DIFF
--- a/scripts/align_long_homopolymers.py
+++ b/scripts/align_long_homopolymers.py
@@ -297,9 +297,10 @@ def realign_homopolymers(cram_path, output_path, reference_path, homopolymer_len
                     if read.cigartuples[0][0] == 4:
                         # the read is soft clipped
                         sc_length = read.cigartuples[0][1]
+                    del_length = sum([length for op, length in read.cigartuples if op == 2])
                     fa_seq = reference[read.reference_name][
                              max(read.reference_start - sc_length, 0): read.reference_start + len(
-                                 sequence) - sc_length].seq.upper()
+                                 sequence) - sc_length + del_length].seq.upper()
                     edited_fa_seq, ref_start_end_del_tuples, ref_del_length = remove_long_homopolymers(fa_seq,
                                                                                                        homopolymer_length)
 

--- a/src/main/java/au/edu/wehi/idsv/AssemblyAttributes.java
+++ b/src/main/java/au/edu/wehi/idsv/AssemblyAttributes.java
@@ -250,12 +250,12 @@ public class AssemblyAttributes {
 		return stream;
 	}
 	public Collection<String> getEvidenceIDs(Range<Integer> assemblyContigOffset, Set<Integer> supportingCategories, Set<AssemblyEvidenceSupport.SupportType> supportTypes, AssemblyEvidenceSource aes) {
-		return filterSupport(assemblyContigOffset, supportingCategories, supportTypes, aes,  aes.getContext())
+		return filterSupport(assemblyContigOffset, supportingCategories, supportTypes, aes,  aes != null ? aes.getContext() : null)
 				.map(s -> s.getEvidenceID())
 				.collect(Collectors.toList());
 	}
 	public Set<String> getOriginatingFragmentID(Range<Integer> assemblyContigOffset, Set<Integer> supportingCategories, Set<AssemblyEvidenceSupport.SupportType> supportTypes, AssemblyEvidenceSource aes) {
-		return filterSupport(assemblyContigOffset, supportingCategories, supportTypes, aes, aes.getContext())
+		return filterSupport(assemblyContigOffset, supportingCategories, supportTypes, aes, aes != null ? aes.getContext() : null)
 				.map(s -> s.getFragmentID())
 				.collect(Collectors.toSet());
 	}
@@ -281,7 +281,7 @@ public class AssemblyAttributes {
 		float best = getSupportingQualScore(assemblyContigOffset.lowerEndpoint(), supportingCategories, supportTypes, aes, aes != null ? aes.getContext() : null);
 		int bestPos = assemblyContigOffset.lowerEndpoint();
 		for (int i = assemblyContigOffset.lowerEndpoint() + 1; i <= assemblyContigOffset.upperEndpoint(); i++) {
-			float current = getSupportingQualScore(i, null, null, aes, aes.getContext());
+			float current = getSupportingQualScore(i, null, null, aes, aes != null ? aes.getContext() : null);
 			if (current > best) {
 				best = current;
 				bestPos = i;

--- a/src/main/java/au/edu/wehi/idsv/AssemblyAttributes.java
+++ b/src/main/java/au/edu/wehi/idsv/AssemblyAttributes.java
@@ -243,10 +243,6 @@ public class AssemblyAttributes {
 		if (supportTypes != null) {
 			stream = stream.filter(s -> supportTypes.contains(s.getSupportType()));
 		}
-
-		// for debugging
-		log.info("assemblyContigOffset: " + assemblyContigOffset);
-		stream = stream.peek(s -> log.info("Support: " + s.getEvidenceID() + " " + s.getAssemblyContigOffset() + " " + s.getQual() + " " + s.getCategory()));
 		return stream;
 	}
 	public Collection<String> getEvidenceIDs(Range<Integer> assemblyContigOffset, Set<Integer> supportingCategories, Set<AssemblyEvidenceSupport.SupportType> supportTypes, AssemblyEvidenceSource aes) {
@@ -263,6 +259,7 @@ public class AssemblyAttributes {
 		if (assemblyContigOffset == null) {
 			throw new NullPointerException("assemblyContigOffset is required.");
 		}
+
 		float best = getSupportingQualScore(assemblyContigOffset.lowerEndpoint(), supportingCategories, supportTypes, aes, aes != null ? aes.getContext() : null);
 		int bestPos = assemblyContigOffset.lowerEndpoint();
 		for (int i = assemblyContigOffset.lowerEndpoint() + 1; i <= assemblyContigOffset.upperEndpoint(); i++) {

--- a/src/main/java/au/edu/wehi/idsv/AssemblyAttributes.java
+++ b/src/main/java/au/edu/wehi/idsv/AssemblyAttributes.java
@@ -266,7 +266,7 @@ public class AssemblyAttributes {
 		float best = getSupportingQualScore(assemblyContigOffset.lowerEndpoint(), supportingCategories, supportTypes, aes, aes != null ? aes.getContext() : null);
 		int bestPos = assemblyContigOffset.lowerEndpoint();
 		for (int i = assemblyContigOffset.lowerEndpoint() + 1; i <= assemblyContigOffset.upperEndpoint(); i++) {
-			float current = getSupportingQualScore(i, null, null, aes,  aes.getContext());
+			float current = getSupportingQualScore(i, null, null, aes,  aes != null ? aes.getContext() : null);
 			if (current < best) {
 				best = current;
 				bestPos = i;
@@ -278,7 +278,7 @@ public class AssemblyAttributes {
 		if (assemblyContigOffset == null) {
 			throw new NullPointerException("assemblyContigOffset is required.");
 		}
-		float best = getSupportingQualScore(assemblyContigOffset.lowerEndpoint(), supportingCategories, supportTypes, aes, aes.getContext());
+		float best = getSupportingQualScore(assemblyContigOffset.lowerEndpoint(), supportingCategories, supportTypes, aes, aes != null ? aes.getContext() : null);
 		int bestPos = assemblyContigOffset.lowerEndpoint();
 		for (int i = assemblyContigOffset.lowerEndpoint() + 1; i <= assemblyContigOffset.upperEndpoint(); i++) {
 			float current = getSupportingQualScore(i, null, null, aes, aes.getContext());

--- a/src/main/java/au/edu/wehi/idsv/AssemblyAttributes.java
+++ b/src/main/java/au/edu/wehi/idsv/AssemblyAttributes.java
@@ -221,19 +221,21 @@ public class AssemblyAttributes {
 		return isUnique;
 	}
 
-	private Stream<AssemblyEvidenceSupport> filterSupport(Range<Integer> assemblyContigOffset, Set<Integer> supportingCategories, Set<AssemblyEvidenceSupport.SupportType> supportTypes, AssemblyEvidenceSource aes) {
+	private Stream<AssemblyEvidenceSupport> filterSupport(Range<Integer> assemblyContigOffset, Set<Integer> supportingCategories, Set<AssemblyEvidenceSupport.SupportType> supportTypes, AssemblyEvidenceSource aes, ProcessingContext context) {
 		Stream<AssemblyEvidenceSupport> stream = getSupport(aes).stream();
 		if (assemblyContigOffset != null) {
 			int requiredReadAndAssemblyBreakpointOverlap;
-			if (aes != null) {
-				requiredReadAndAssemblyBreakpointOverlap = aes.getContext().getConfig().getVariantCalling().requiredReadAndAssemblyBreakpointOverlap;
+			if (context != null) {
+				requiredReadAndAssemblyBreakpointOverlap = context.getConfig().getVariantCalling().requiredReadAndAssemblyBreakpointOverlap;
 			} else {
 				requiredReadAndAssemblyBreakpointOverlap = 0;
 			}
-			stream = stream.filter(s -> Range.range(Math.min(s.getAssemblyContigOffset().lowerEndpoint() + requiredReadAndAssemblyBreakpointOverlap, s.getAssemblyContigOffset().upperEndpoint() - requiredReadAndAssemblyBreakpointOverlap),
+			stream = stream.filter(s -> Range.range(
+					Math.min(s.getAssemblyContigOffset().lowerEndpoint() + requiredReadAndAssemblyBreakpointOverlap, s.getAssemblyContigOffset().upperEndpoint() - requiredReadAndAssemblyBreakpointOverlap),
 					s.getAssemblyContigOffset().lowerBoundType(),
-					Math.max(s.getAssemblyContigOffset().upperEndpoint() - requiredReadAndAssemblyBreakpointOverlap, s.getAssemblyContigOffset().lowerEndpoint() + requiredReadAndAssemblyBreakpointOverlap),
-					s.getAssemblyContigOffset().upperBoundType()).isConnected(assemblyContigOffset));
+					Math.max(s.getAssemblyContigOffset().upperEndpoint() - requiredReadAndAssemblyBreakpointOverlap,s.getAssemblyContigOffset().lowerEndpoint() + requiredReadAndAssemblyBreakpointOverlap),
+					s.getAssemblyContigOffset().upperBoundType()
+			).isConnected(assemblyContigOffset));
 		}
 		if (supportingCategories != null) {
 			stream = stream.filter(s -> supportingCategories.contains(s.getCategory()));
@@ -241,15 +243,19 @@ public class AssemblyAttributes {
 		if (supportTypes != null) {
 			stream = stream.filter(s -> supportTypes.contains(s.getSupportType()));
 		}
+
+		// for debugging
+		log.info("assemblyContigOffset: " + assemblyContigOffset);
+		stream = stream.peek(s -> log.info("Support: " + s.getEvidenceID() + " " + s.getAssemblyContigOffset() + " " + s.getQual() + " " + s.getCategory()));
 		return stream;
 	}
 	public Collection<String> getEvidenceIDs(Range<Integer> assemblyContigOffset, Set<Integer> supportingCategories, Set<AssemblyEvidenceSupport.SupportType> supportTypes, AssemblyEvidenceSource aes) {
-		return filterSupport(assemblyContigOffset, supportingCategories, supportTypes, aes)
+		return filterSupport(assemblyContigOffset, supportingCategories, supportTypes, aes,  aes.getContext())
 				.map(s -> s.getEvidenceID())
 				.collect(Collectors.toList());
 	}
 	public Set<String> getOriginatingFragmentID(Range<Integer> assemblyContigOffset, Set<Integer> supportingCategories, Set<AssemblyEvidenceSupport.SupportType> supportTypes, AssemblyEvidenceSource aes) {
-		return filterSupport(assemblyContigOffset, supportingCategories, supportTypes, aes)
+		return filterSupport(assemblyContigOffset, supportingCategories, supportTypes, aes, aes.getContext())
 				.map(s -> s.getFragmentID())
 				.collect(Collectors.toSet());
 	}
@@ -257,10 +263,10 @@ public class AssemblyAttributes {
 		if (assemblyContigOffset == null) {
 			throw new NullPointerException("assemblyContigOffset is required.");
 		}
-		float best = getSupportingQualScore(assemblyContigOffset.lowerEndpoint(), supportingCategories, supportTypes, aes);
+		float best = getSupportingQualScore(assemblyContigOffset.lowerEndpoint(), supportingCategories, supportTypes, aes, aes != null ? aes.getContext() : null);
 		int bestPos = assemblyContigOffset.lowerEndpoint();
 		for (int i = assemblyContigOffset.lowerEndpoint() + 1; i <= assemblyContigOffset.upperEndpoint(); i++) {
-			float current = getSupportingQualScore(i, null, null, aes);
+			float current = getSupportingQualScore(i, null, null, aes,  aes.getContext());
 			if (current < best) {
 				best = current;
 				bestPos = i;
@@ -272,10 +278,10 @@ public class AssemblyAttributes {
 		if (assemblyContigOffset == null) {
 			throw new NullPointerException("assemblyContigOffset is required.");
 		}
-		float best = getSupportingQualScore(assemblyContigOffset.lowerEndpoint(), supportingCategories, supportTypes, aes);
+		float best = getSupportingQualScore(assemblyContigOffset.lowerEndpoint(), supportingCategories, supportTypes, aes, aes.getContext());
 		int bestPos = assemblyContigOffset.lowerEndpoint();
 		for (int i = assemblyContigOffset.lowerEndpoint() + 1; i <= assemblyContigOffset.upperEndpoint(); i++) {
-			float current = getSupportingQualScore(i, null, null, aes);
+			float current = getSupportingQualScore(i, null, null, aes, aes.getContext());
 			if (current > best) {
 				best = current;
 				bestPos = i;
@@ -283,14 +289,14 @@ public class AssemblyAttributes {
 		}
 		return bestPos;
 	}
-	public int getSupportingReadCount(Range<Integer> assemblyContigOffset, Set<Integer> supportingCategories, Set<AssemblyEvidenceSupport.SupportType> supportTypes, AssemblyEvidenceSource aes) {
-		return (int)filterSupport(assemblyContigOffset, supportingCategories, supportTypes, aes).count();
+	public int getSupportingReadCount(Range<Integer> assemblyContigOffset, Set<Integer> supportingCategories, Set<AssemblyEvidenceSupport.SupportType> supportTypes, AssemblyEvidenceSource aes, ProcessingContext context) {
+		return (int)filterSupport(assemblyContigOffset, supportingCategories, supportTypes, aes, context).count();
 	}
-	public int getSupportingReadCount(int assemblyContigOffset, Set<Integer> supportingCategories, Set<AssemblyEvidenceSupport.SupportType> supportTypes, AssemblyEvidenceSource aes) {
-		return (int)filterSupport(Range.closed(assemblyContigOffset, assemblyContigOffset), supportingCategories, supportTypes, aes).count();
+	public int getSupportingReadCount(int assemblyContigOffset, Set<Integer> supportingCategories, Set<AssemblyEvidenceSupport.SupportType> supportTypes, AssemblyEvidenceSource aes, ProcessingContext context) {
+		return (int)filterSupport(Range.closed(assemblyContigOffset, assemblyContigOffset), supportingCategories, supportTypes, aes, context).count();
 	}
-	public float getSupportingQualScore(int assemblyContigOffset, Set<Integer> supportingCategories, Set<AssemblyEvidenceSupport.SupportType> supportTypes, AssemblyEvidenceSource aes) {
-		return (float)filterSupport(Range.closed(assemblyContigOffset, assemblyContigOffset), supportingCategories, supportTypes, aes).mapToDouble(s -> s.getQual()).sum();
+	public float getSupportingQualScore(int assemblyContigOffset, Set<Integer> supportingCategories, Set<AssemblyEvidenceSupport.SupportType> supportTypes, AssemblyEvidenceSource aes, ProcessingContext context) {
+		return (float)filterSupport(Range.closed(assemblyContigOffset, assemblyContigOffset), supportingCategories, supportTypes, aes, context).mapToDouble(s -> s.getQual()).sum();
 	}
 	public int getAssemblyMaxReadLength() {
 		return record.getIntegerAttribute(SamTags.ASSEMBLY_MAX_READ_LENGTH);

--- a/src/main/java/au/edu/wehi/idsv/IndelEvidence.java
+++ b/src/main/java/au/edu/wehi/idsv/IndelEvidence.java
@@ -131,10 +131,10 @@ public class IndelEvidence extends SingleReadEvidence implements DirectedBreakpo
 	private float scoreAssembly() {
 		AssemblyAttributes attr = new AssemblyAttributes(getSAMRecord());
 		int pos = getBreakendAssemblyContigOffset();
-		int rp = attr.getSupportingReadCount(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null);
-		double rpq = attr.getSupportingQualScore(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null);
-		int sc = attr.getSupportingReadCount(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null);
-		double scq = attr.getSupportingQualScore(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null);
+		int rp = attr.getSupportingReadCount(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, source.getContext());
+		double rpq = attr.getSupportingQualScore(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, source.getContext());
+		int sc = attr.getSupportingReadCount(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null, source.getContext());
+		double scq = attr.getSupportingQualScore(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null, source.getContext());
 		return (float)getEvidenceSource().getContext().getConfig().getScoring().getModel().scoreAssembly(this,
 				rp, rpq,
 				sc, scq,

--- a/src/main/java/au/edu/wehi/idsv/SingleReadEvidence.java
+++ b/src/main/java/au/edu/wehi/idsv/SingleReadEvidence.java
@@ -488,7 +488,6 @@ public abstract class SingleReadEvidence implements DirectedEvidence {
 	public int getBreakendAssemblyContigOffset() {
 		if (assemblyOffset == Integer.MIN_VALUE && AssemblyAttributes.isAssembly(record)) {
 			AssemblyAttributes aa = new AssemblyAttributes(record);
-			log.info("Calculating assembly offset for " + record.getReadName());
 			assemblyOffset = aa.getMinQualPosition(getBreakendAssemblyContigBreakpointInterval(), null, null, null);
 		}
 		return assemblyOffset;

--- a/src/main/java/au/edu/wehi/idsv/SingleReadEvidence.java
+++ b/src/main/java/au/edu/wehi/idsv/SingleReadEvidence.java
@@ -426,7 +426,7 @@ public abstract class SingleReadEvidence implements DirectedEvidence {
 	public int constituentReads() {
 		if (AssemblyAttributes.isAssembly(getSAMRecord())) {
 			AssemblyAttributes aa = new AssemblyAttributes(record);
-			return aa.getSupportingReadCount(getBreakendAssemblyContigOffset(), null, null, null);
+			return aa.getSupportingReadCount(getBreakendAssemblyContigOffset(), null, null, null, source.getContext());
 		}
 		return 1;
 	}
@@ -488,6 +488,7 @@ public abstract class SingleReadEvidence implements DirectedEvidence {
 	public int getBreakendAssemblyContigOffset() {
 		if (assemblyOffset == Integer.MIN_VALUE && AssemblyAttributes.isAssembly(record)) {
 			AssemblyAttributes aa = new AssemblyAttributes(record);
+			log.info("Calculating assembly offset for " + record.getReadName());
 			assemblyOffset = aa.getMinQualPosition(getBreakendAssemblyContigBreakpointInterval(), null, null, null);
 		}
 		return assemblyOffset;

--- a/src/main/java/au/edu/wehi/idsv/SoftClipEvidence.java
+++ b/src/main/java/au/edu/wehi/idsv/SoftClipEvidence.java
@@ -9,9 +9,11 @@ import htsjdk.samtools.Cigar;
 import htsjdk.samtools.CigarElement;
 import htsjdk.samtools.CigarOperator;
 import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.util.Log;
 
 public class SoftClipEvidence extends SingleReadEvidence {
 	private final int clipLength;
+	private static final Log log = Log.getInstance(SoftClipEvidence.class);
 	protected SoftClipEvidence(SAMEvidenceSource source, SAMRecord record, BreakendSummary location,
 			int offsetLocalStart, int offsetLocalEnd,
 			int offsetUnmappedStart, int offsetUnmappedEnd,
@@ -66,10 +68,15 @@ public class SoftClipEvidence extends SingleReadEvidence {
 	private float scoreAssembly() {
 		AssemblyAttributes attr = new AssemblyAttributes(getSAMRecord());
 		int pos = getBreakendAssemblyContigOffset();
-		int rp = attr.getSupportingReadCount(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null);
-		double rpq = attr.getSupportingQualScore(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null);
-		int sc = attr.getSupportingReadCount(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null);
-		double scq = attr.getSupportingQualScore(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null);
+		log.info("Scoring assembly at " + pos);
+		int rp = attr.getSupportingReadCount(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, source.getContext());
+		log.info("Read pair support: " + rp);
+		double rpq = attr.getSupportingQualScore(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, source.getContext());
+		log.info("Read pair quality: " + rpq);
+		int sc = attr.getSupportingReadCount(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null, source.getContext());
+		log.info("Read support: " + sc);
+		double scq = attr.getSupportingQualScore(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null, source.getContext());
+		log.info("Read quality: " + scq);
 		return (float)getEvidenceSource().getContext().getConfig().getScoring().getModel().scoreBreakendAssembly(this,
 				rp, rpq,
 				sc, scq,

--- a/src/main/java/au/edu/wehi/idsv/SoftClipEvidence.java
+++ b/src/main/java/au/edu/wehi/idsv/SoftClipEvidence.java
@@ -68,15 +68,10 @@ public class SoftClipEvidence extends SingleReadEvidence {
 	private float scoreAssembly() {
 		AssemblyAttributes attr = new AssemblyAttributes(getSAMRecord());
 		int pos = getBreakendAssemblyContigOffset();
-		log.info("Scoring assembly at " + pos);
 		int rp = attr.getSupportingReadCount(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, source.getContext());
-		log.info("Read pair support: " + rp);
 		double rpq = attr.getSupportingQualScore(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, source.getContext());
-		log.info("Read pair quality: " + rpq);
 		int sc = attr.getSupportingReadCount(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null, source.getContext());
-		log.info("Read support: " + sc);
 		double scq = attr.getSupportingQualScore(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null, source.getContext());
-		log.info("Read quality: " + scq);
 		return (float)getEvidenceSource().getContext().getConfig().getScoring().getModel().scoreBreakendAssembly(this,
 				rp, rpq,
 				sc, scq,

--- a/src/main/java/au/edu/wehi/idsv/SplitReadEvidence.java
+++ b/src/main/java/au/edu/wehi/idsv/SplitReadEvidence.java
@@ -167,10 +167,10 @@ public class SplitReadEvidence extends SingleReadEvidence implements DirectedBre
 	private float scoreAssembly() {
 		AssemblyAttributes attr = new AssemblyAttributes(getSAMRecord());
 		int pos = getBreakendAssemblyContigOffset();
-		int rp = attr.getSupportingReadCount(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null);
-		double rpq = attr.getSupportingQualScore(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null);
-		int sc = attr.getSupportingReadCount(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null);
-		double scq = attr.getSupportingQualScore(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null);
+		int rp = attr.getSupportingReadCount(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, source.getContext());
+		double rpq = attr.getSupportingQualScore(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, source.getContext());
+		int sc = attr.getSupportingReadCount(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null, source.getContext());
+		double scq = attr.getSupportingQualScore(pos, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null, source.getContext());
 		return (float)getEvidenceSource().getContext().getConfig().getScoring().getModel().scoreAssembly(this,
 				rp, rpq,
 				sc, scq,

--- a/src/main/java/au/edu/wehi/idsv/StructuralVariationCallBuilder.java
+++ b/src/main/java/au/edu/wehi/idsv/StructuralVariationCallBuilder.java
@@ -388,7 +388,7 @@ public class StructuralVariationCallBuilder extends IdsvVariantContextBuilder {
 					SingleReadEvidence e = (SingleReadEvidence) de;
 					if (AssemblyAttributes.isAssembly(e)) {
 						AssemblyAttributes aa = aaLookup.get(de);
-						int asmReads = aa.getSupportingReadCount(null, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null);
+						int asmReads = aa.getSupportingReadCount(null, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null, processContext);
 						reads += asmReads;
 						strandReads += aa.getStrandBias() * asmReads;
 					} else {
@@ -431,28 +431,31 @@ public class StructuralVariationCallBuilder extends IdsvVariantContextBuilder {
 								ass.getBreakendAssemblyContigOffset(),
 								ImmutableSet.of(category),
 								ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read),
-								(AssemblyEvidenceSource)ass.getEvidenceSource()))
+								(AssemblyEvidenceSource)ass.getEvidenceSource(), processContext))
 						.sum();
 				asrp[category] = Stream.concat(Stream.concat(supportingAS.stream(), supportingRAS.stream()), supportingCAS.stream())
 						.mapToInt(ass -> aaLookup.get(ass).getSupportingReadCount(
 								ass.getBreakendAssemblyContigOffset(),
 								ImmutableSet.of(category),
 								ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair),
-								(AssemblyEvidenceSource)ass.getEvidenceSource()))
+								(AssemblyEvidenceSource)ass.getEvidenceSource(),
+                                ass.source.getContext()))
 						.sum();
 				basr[category] = supportingBAS.stream()
 						.mapToInt(ass -> aaLookup.get(ass).getSupportingReadCount(
 								ass.getBreakendAssemblyContigOffset(),
 								ImmutableSet.of(category),
 								ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read),
-								(AssemblyEvidenceSource)ass.getEvidenceSource()))
+								(AssemblyEvidenceSource)ass.getEvidenceSource(),
+                                ass.source.getContext()))
 						.sum();
 				basrp[category] = supportingBAS.stream()
 						.mapToInt(ass -> aaLookup.get(ass).getSupportingReadCount(
 								ass.getBreakendAssemblyContigOffset(),
 								ImmutableSet.of(category),
 								ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair),
-								(AssemblyEvidenceSource)ass.getEvidenceSource()))
+								(AssemblyEvidenceSource)ass.getEvidenceSource(),
+                                ass.source.getContext()))
 						.sum();
 
 				genotypeBuilder.get(category).attribute(VcfFormatAttributes.BREAKPOINT_ASSEMBLY_READ_COUNT.attribute(), asr[category]);
@@ -587,7 +590,7 @@ public class StructuralVariationCallBuilder extends IdsvVariantContextBuilder {
 			double assQual = (ass instanceof DirectedBreakpoint) ? ((DirectedBreakpoint)ass).getBreakpointQual() : ass.getBreakendQual();
 			double[] breakdownQual = new double[processContext.getCategoryCount()];
 			for (int i = 0; i < breakdownQual.length; i++) {
-				breakdownQual[i] = aa.getSupportingQualScore(offset, ImmutableSet.of(i), null, (AssemblyEvidenceSource)ass.getEvidenceSource());
+				breakdownQual[i] = aa.getSupportingQualScore(offset, ImmutableSet.of(i), null, (AssemblyEvidenceSource)ass.getEvidenceSource(), processContext);
 			}
 			double breakdownTotal = DoubleStream.of(breakdownQual).sum();
 			if (breakdownTotal != 0) { // defensive check to mitigate impact of 0 qual assemblies (#156)

--- a/src/main/java/gridss/AllocateEvidence.java
+++ b/src/main/java/gridss/AllocateEvidence.java
@@ -113,7 +113,6 @@ public class AllocateEvidence extends VcfTransformCommandLineProgram {
 		return new AutoClosingIterator<>(new AssemblyAssociator(it, mergedAssemblies, windowSize), assToClose.toArray(new Closeable[0]));
 	}
 	private VariantContextDirectedEvidence annotate(VariantEvidenceSupport ves) {
-		log.info("Variant:" + ves.variant.getID());
 		VariantCallingConfiguration vc = getContext().getConfig().getVariantCalling();
 		StructuralVariationCallBuilder builder = new StructuralVariationCallBuilder(getContext(), lookup, ves.variant);
 		builder.setUpdateAssemblyInformation(ALLOCATE_ASSEMBLIES);

--- a/src/main/java/gridss/AllocateEvidence.java
+++ b/src/main/java/gridss/AllocateEvidence.java
@@ -113,6 +113,7 @@ public class AllocateEvidence extends VcfTransformCommandLineProgram {
 		return new AutoClosingIterator<>(new AssemblyAssociator(it, mergedAssemblies, windowSize), assToClose.toArray(new Closeable[0]));
 	}
 	private VariantContextDirectedEvidence annotate(VariantEvidenceSupport ves) {
+		log.info("Variant:" + ves.variant.getID());
 		VariantCallingConfiguration vc = getContext().getConfig().getVariantCalling();
 		StructuralVariationCallBuilder builder = new StructuralVariationCallBuilder(getContext(), lookup, ves.variant);
 		builder.setUpdateAssemblyInformation(ALLOCATE_ASSEMBLIES);

--- a/src/test/java/au/edu/wehi/idsv/AssemblyFactoryTest.java
+++ b/src/test/java/au/edu/wehi/idsv/AssemblyFactoryTest.java
@@ -100,8 +100,8 @@ public class AssemblyFactoryTest extends TestHelper {
 	}
 	@Test
 	public void should_set_assembly_attribute_ASSEMBLY_READPAIR_COUNT() {
-		assertEquals(2, new AssemblyAttributes(bigr()).getSupportingReadCount(bigr().getBreakendAssemblyContigOffset(), ImmutableSet.of(0), ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), (AssemblyEvidenceSource)bigr().source));
-		assertEquals(4, new AssemblyAttributes(bigr()).getSupportingReadCount(bigr().getBreakendAssemblyContigOffset(), ImmutableSet.of(1), ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), (AssemblyEvidenceSource)bigr().source));
+		assertEquals(2, new AssemblyAttributes(bigr()).getSupportingReadCount(bigr().getBreakendAssemblyContigOffset(), ImmutableSet.of(0), ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), (AssemblyEvidenceSource)bigr().source, null));
+		assertEquals(4, new AssemblyAttributes(bigr()).getSupportingReadCount(bigr().getBreakendAssemblyContigOffset(), ImmutableSet.of(1), ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), (AssemblyEvidenceSource)bigr().source, null));
 	}
 	@Test
 	public void should_set_assembly_attribute_ASSEMBLY_READPAIR_LENGTH_MAX() {
@@ -109,8 +109,8 @@ public class AssemblyFactoryTest extends TestHelper {
 	}
 	@Test
 	public void should_set_assembly_attribute_ASSEMBLY_SOFTCLIP_COUNT() {
-		assertEquals(1, new AssemblyAttributes(bigr()).getSupportingReadCount(bigr().getBreakendAssemblyContigOffset(), ImmutableSet.of(0), ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), (AssemblyEvidenceSource)bigr().source));
-		assertEquals(2, new AssemblyAttributes(bigr()).getSupportingReadCount(bigr().getBreakendAssemblyContigOffset(), ImmutableSet.of(1), ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), (AssemblyEvidenceSource)bigr().source));
+		assertEquals(1, new AssemblyAttributes(bigr()).getSupportingReadCount(bigr().getBreakendAssemblyContigOffset(), ImmutableSet.of(0), ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), (AssemblyEvidenceSource)bigr().source, null));
+		assertEquals(2, new AssemblyAttributes(bigr()).getSupportingReadCount(bigr().getBreakendAssemblyContigOffset(), ImmutableSet.of(1), ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), (AssemblyEvidenceSource)bigr().source, null));
 	}
 //	@Test
 //	public void should_set_assembly_attribute_ASSEMBLY_REMOTE_COUNT() {

--- a/src/test/java/au/edu/wehi/idsv/SAMRecordAssemblyEvidenceTest.java
+++ b/src/test/java/au/edu/wehi/idsv/SAMRecordAssemblyEvidenceTest.java
@@ -116,8 +116,8 @@ public class SAMRecordAssemblyEvidenceTest extends TestHelper {
 		assertTrue(e.isPartOfAssembly(e3));
 		assertFalse(e.isPartOfAssembly(b1));
 		
-		assertEquals(2, (int)e.getSupportingReadCount(1, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null));
-		assertEquals(1, (int)e.getSupportingReadCount(1, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null));
+		assertEquals(2, (int)e.getSupportingReadCount(1, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null, null));
+		assertEquals(1, (int)e.getSupportingReadCount(1, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, null));
 	}
 	@Test
 	public void should_track_read_name() {

--- a/src/test/java/au/edu/wehi/idsv/debruijn/positional/NonReferenceContigAssemblerTest.java
+++ b/src/test/java/au/edu/wehi/idsv/debruijn/positional/NonReferenceContigAssemblerTest.java
@@ -71,7 +71,7 @@ public class NonReferenceContigAssemblerTest extends TestHelper {
 		List<SAMRecord> output = go(pc, sce);
 		AssemblyAttributes attr = new AssemblyAttributes(output.get(0));
 		assertNotNull(attr);
-		assertEquals(1, attr.getSupportingReadCount(5, null, null, null));
+		assertEquals(1, attr.getSupportingReadCount(5, null, null, null, null));
 	}
 	@Test
 	public void should_call_simple_bwd_SC() {
@@ -437,11 +437,11 @@ public class NonReferenceContigAssemblerTest extends TestHelper {
 		AssemblyAttributes aa = new AssemblyAttributes(output.get(0));
 		// GGTTGCATAGACGTGGTCGACCTAGTA
 		// 012345678901234567890123456
-		assertEquals(0, aa.getSupportingReadCount(0, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null));
+		assertEquals(0, aa.getSupportingReadCount(0, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, null));
 		for (int i = 1; i <= 26; i++) {
-			assertEquals(1, aa.getSupportingReadCount(i, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null));
+			assertEquals(1, aa.getSupportingReadCount(i, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, null));
 		}
-		assertEquals(0, aa.getSupportingReadCount(27, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null));
+		assertEquals(0, aa.getSupportingReadCount(27, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, null));
 	}
 	@Test
 	public void rp_support_without_anchor_should_extend_to_contig_start() {
@@ -460,9 +460,9 @@ public class NonReferenceContigAssemblerTest extends TestHelper {
 		// CATAGACGTGGTCGACCTAGTA
 		// 0123456789012345678901
 		for (int i = 0; i <= 21; i++) {
-			assertEquals(1, aa.getSupportingReadCount(i, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null));
+			assertEquals(1, aa.getSupportingReadCount(i, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, null));
 		}
-		assertEquals(0, aa.getSupportingReadCount(22, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null));
+		assertEquals(0, aa.getSupportingReadCount(22, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, null));
 	}
 
 	@Test
@@ -482,11 +482,11 @@ public class NonReferenceContigAssemblerTest extends TestHelper {
 		AssemblyAttributes aa = new AssemblyAttributes(output.get(0));
 		// GGTTGCATAGACGTGGTCGACC
 		// 0123456789012345678901
-		assertEquals(0, aa.getSupportingReadCount(0, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null));
+		assertEquals(0, aa.getSupportingReadCount(0, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, null));
 		for (int i = 1; i < output.get(0).getReadLength(); i++) {
-			assertEquals(1, aa.getSupportingReadCount(i, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null));
+			assertEquals(1, aa.getSupportingReadCount(i, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, null));
 		}
-		assertEquals(0, aa.getSupportingReadCount(output.get(0).getReadLength(), null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null));
+		assertEquals(0, aa.getSupportingReadCount(output.get(0).getReadLength(), null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, null));
 	}
 	@Test
 	public void should_not_write_inconsistent_anchors() {
@@ -525,15 +525,15 @@ public class NonReferenceContigAssemblerTest extends TestHelper {
 		assertEquals("1X29N1X10S", output.get(0).getCigarString());
 		// 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4
 		//  * * M M M M M M M M M M - -
-		assertEquals(0, aa.getSupportingReadCount(0, null, null, null));
-		assertEquals(0, aa.getSupportingReadCount(1, null, null, null));
-		assertEquals(1, aa.getSupportingReadCount(2, null, null, null));
-		assertEquals(1, aa.getSupportingReadCount(3, null, null, null));
-		assertEquals(1, aa.getSupportingReadCount(4, null, null, null));
-		assertEquals(1, aa.getSupportingReadCount(10, null, null, null));
-		assertEquals(1, aa.getSupportingReadCount(11, null, null, null));
-		assertEquals(0, aa.getSupportingReadCount(12, null, null, null));
-		assertEquals(0, aa.getSupportingReadCount(13, null, null, null));
+		assertEquals(0, aa.getSupportingReadCount(0, null, null, null, null));
+		assertEquals(0, aa.getSupportingReadCount(1, null, null, null, null));
+		assertEquals(1, aa.getSupportingReadCount(2, null, null, null, null));
+		assertEquals(1, aa.getSupportingReadCount(3, null, null, null, null));
+		assertEquals(1, aa.getSupportingReadCount(4, null, null, null, null));
+		assertEquals(1, aa.getSupportingReadCount(10, null, null, null, null));
+		assertEquals(1, aa.getSupportingReadCount(11, null, null, null, null));
+		assertEquals(0, aa.getSupportingReadCount(12, null, null, null, null));
+		assertEquals(0, aa.getSupportingReadCount(13, null, null, null, null));
 	}
 	@Test
 	public void unanchored_rp_should_support_at_contig_bounds_but_not_padding_bases_BWD() {
@@ -554,16 +554,16 @@ public class NonReferenceContigAssemblerTest extends TestHelper {
 		assertEquals(0, aa.getSupportingReadCount(0, null, null, null));
 		//  0 1 2 3 4 5 6 7 8 9 0 1 2 3
 		// M M M M M M M M M M * * - -
-		assertEquals(0, aa.getSupportingReadCount(0, null, null, null));
-		assertEquals(1, aa.getSupportingReadCount(1, null, null, null));
-		assertEquals(1, aa.getSupportingReadCount(2, null, null, null));
-		assertEquals(1, aa.getSupportingReadCount(3, null, null, null));
-		assertEquals(1, aa.getSupportingReadCount(8, null, null, null));
-		assertEquals(1, aa.getSupportingReadCount(9, null, null, null));
-		assertEquals(0, aa.getSupportingReadCount(10, null, null, null));
-		assertEquals(0, aa.getSupportingReadCount(11, null, null, null));
-		assertEquals(0, aa.getSupportingReadCount(12, null, null, null));
-		assertEquals(0, aa.getSupportingReadCount(13, null, null, null));
+		assertEquals(0, aa.getSupportingReadCount(0, null, null, null, null));
+		assertEquals(1, aa.getSupportingReadCount(1, null, null, null, null));
+		assertEquals(1, aa.getSupportingReadCount(2, null, null, null, null));
+		assertEquals(1, aa.getSupportingReadCount(3, null, null, null, null));
+		assertEquals(1, aa.getSupportingReadCount(8, null, null, null, null));
+		assertEquals(1, aa.getSupportingReadCount(9, null, null, null, null));
+		assertEquals(0, aa.getSupportingReadCount(10, null, null, null, null));
+		assertEquals(0, aa.getSupportingReadCount(11, null, null, null, null));
+		assertEquals(0, aa.getSupportingReadCount(12, null, null, null, null));
+		assertEquals(0, aa.getSupportingReadCount(13, null, null, null, null));
 	}
 	@Test
 	public void issue287_rp_support_for_anchor_with_no_valid_kmers_treated_as_anchoring_read_not_assembled() {
@@ -582,11 +582,11 @@ public class NonReferenceContigAssemblerTest extends TestHelper {
 		AssemblyAttributes aa = new AssemblyAttributes(output.get(0));
 		// GGTTGCATAGACGTGGTCGACC
 		// 0123456789012345678901
-		assertEquals(0, aa.getSupportingReadCount(0, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null));
+		assertEquals(0, aa.getSupportingReadCount(0, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, null));
 		for (int i = 1; i < output.get(0).getReadLength(); i++) {
-			assertEquals(1, aa.getSupportingReadCount(i, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null));
+			assertEquals(1, aa.getSupportingReadCount(i, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, null));
 		}
-		assertEquals(0, aa.getSupportingReadCount(output.get(0).getReadLength(), null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null));
+		assertEquals(0, aa.getSupportingReadCount(output.get(0).getReadLength(), null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, null));
 	}
 	@Test
 	@Ignore // TODO: better approach to reassembly after detecting misassembly

--- a/src/test/java/au/edu/wehi/idsv/debruijn/positional/PositionalAssemblerTest.java
+++ b/src/test/java/au/edu/wehi/idsv/debruijn/positional/PositionalAssemblerTest.java
@@ -59,12 +59,12 @@ public class PositionalAssemblerTest extends TestHelper {
         AssemblyAttributes aa = new AssemblyAttributes(r.get(0).getSAMRecord());
                                   // A A C G T T G G T T A A
         int[] expected = new int[] {1,1,2,2,2,2,2,2,2,2,2,1,0,};
-        int[] actual = IntStream.range(0, 12+1).map(i -> aa.getSupportingReadCount(i, null, null, null)).toArray();
+        int[] actual = IntStream.range(0, 12+1).map(i -> aa.getSupportingReadCount(i, null, null, null, null)).toArray();
 		assertArrayEquals(expected, actual);
-        assertArrayEquals(expected, IntStream.range(0, 12+1).map(i -> aa.getSupportingReadCount(i, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null)).toArray());
-        assertArrayEquals(expected, IntStream.range(0, 12+1).map(i -> aa.getSupportingReadCount(i, ImmutableSet.of(0), ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), aes)).toArray());
-        assertArrayEquals(new int[13], IntStream.range(0, 12+1).map(i -> aa.getSupportingReadCount(i, ImmutableSet.of(1), null, aes)).toArray());
-        assertArrayEquals(new double[13], IntStream.range(0, 12+1).mapToDouble(i -> aa.getSupportingQualScore(i, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null)).toArray(), 0);
+        assertArrayEquals(expected, IntStream.range(0, 12+1).map(i -> aa.getSupportingReadCount(i, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), null, null)).toArray());
+        assertArrayEquals(expected, IntStream.range(0, 12+1).map(i -> aa.getSupportingReadCount(i, ImmutableSet.of(0), ImmutableSet.of(AssemblyEvidenceSupport.SupportType.Read), aes, null)).toArray());
+        assertArrayEquals(new int[13], IntStream.range(0, 12+1).map(i -> aa.getSupportingReadCount(i, ImmutableSet.of(1), null, aes, null)).toArray());
+        assertArrayEquals(new double[13], IntStream.range(0, 12+1).mapToDouble(i -> aa.getSupportingQualScore(i, null, ImmutableSet.of(AssemblyEvidenceSupport.SupportType.ReadPair), null, null)).toArray(), 0);
 	}
 	@Test
 	public void rp_anchor_should_set_non_reference_bases_as_anchoring() {
@@ -129,7 +129,7 @@ public class PositionalAssemblerTest extends TestHelper {
 		input.add(IE(withSequence(seq, Read(0, 10, "5M100D5M"))[0]));
 		input.sort(DirectedEvidenceOrder.ByStartEndStart2End2);
 		SAMRecord r = Lists.newArrayList(new PositionalAssembler(pc, aes, new SequentialIdGenerator("asm"), input.iterator(), null, null)).get(0);
-		assertEquals(2, new AssemblyAttributes(r).getSupportingReadCount(6, null, null, null));
+		assertEquals(2, new AssemblyAttributes(r).getSupportingReadCount(6, null, null, null, null));
 	}
 	@Test
 	public void should_set_assembly_direction() {


### PR DESCRIPTION
**Fix in gridss**: In IdentifyVariants we saw that the overlap of 0 is also considered as overlap. Overlap of 0 means that there is not SC in the read, the alignment between the haplotype and the read is perfect in the region which is not SC. Hence, also reads which are not overlapping the SC end are considered and increase the qual and then we have fake variants

**Fix in align_long_homopolymers.py**: We saw that in case of a long deletion in the haplotype, we should give reference in the length of the read + the length of the deletion, otherwise, the alignment at the end of the read does not align to the reference and we have a fake sc.