### PR TITLE
DATA-9857 Share gridss docker pre-build resources via composite action

### DIFF
--- a/.github/actions/download-docker-resources/action.yml
+++ b/.github/actions/download-docker-resources/action.yml
@@ -1,0 +1,32 @@
+name: "Download gridss docker resources"
+description: "Download RepeatMasker and rmblast tarballs from GCS and upload them as a build artifact"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Authenticate to Google Cloud
+      id: auth
+      uses: google-github-actions/auth@v2
+      with:
+        token_format: access_token
+        workload_identity_provider: projects/55428976747/locations/global/workloadIdentityPools/devops-pool/providers/devops-pool-provider
+        service_account: gcr-push-sa@ultima-data-307918.iam.gserviceaccount.com
+
+    - name: Install gsutil
+      uses: google-github-actions/setup-gcloud@v1
+      with:
+        version: ">= 363.0.0"
+
+    - name: Download resources
+      shell: bash
+      run: |
+        gsutil cp gs://concordance-data/scripts/RepeatMasker-4.1.2-p1.tar.gz RepeatMasker-4.1.2-p1.tar.gz
+        gsutil cp gs://concordance-data/scripts/rmblast-2.14.1+-x64-linux.tar.gz rmblast-2.14.1+-x64-linux.tar.gz
+
+    - name: Upload resources
+      uses: actions/upload-artifact@v4
+      with:
+        name: docker-resources
+        path: |
+          RepeatMasker-4.1.2-p1.tar.gz
+          rmblast-2.14.1+-x64-linux.tar.gz

--- a/.github/workflows/build-gridss-docker.yml
+++ b/.github/workflows/build-gridss-docker.yml
@@ -11,38 +11,14 @@ on:
 permissions:
   id-token: write # Required for assuming an AWS role
   contents: read # Required for actions/checkout
-env:
-  GCP_WORKLOAD_IDENTITY_PROVIDER: projects/55428976747/locations/global/workloadIdentityPools/devops-pool/providers/devops-pool-provider
-  GCP_SERVICE_ACCOUNT: gcr-push-sa@ultima-data-307918.iam.gserviceaccount.com
+
 jobs:
   pre-build:
     runs-on: ubuntu-latest
     steps:
-      - name: Authenticate to Google Cloud
-        id: auth
-        uses: google-github-actions/auth@v2
-        with:
-          token_format: access_token
-          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
-      - name: Install gsutil 
-        uses: 'google-github-actions/setup-gcloud@v1'
-        with:
-          version: '>= 363.0.0'
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/download-docker-resources
 
-      - name: Download resources
-        run: |
-          gsutil cp gs://concordance-data/scripts/RepeatMasker-4.1.2-p1.tar.gz RepeatMasker-4.1.2-p1.tar.gz
-          gsutil cp gs://concordance-data/scripts/rmblast-2.14.1+-x64-linux.tar.gz rmblast-2.14.1+-x64-linux.tar.gz
-          
-      - name: Upload resources
-        uses: actions/upload-artifact@v4
-        with:
-          name: docker-resources
-          path: |
-            RepeatMasker-4.1.2-p1.tar.gz
-            rmblast-2.14.1+-x64-linux.tar.gz
-          
   build:
     needs: [pre-build]
     uses: Ultimagen/ugbio-utils/.github/workflows/docker-build-push.yml@main

--- a/.github/workflows/release-gridss-docker.yaml
+++ b/.github/workflows/release-gridss-docker.yaml
@@ -27,7 +27,7 @@ jobs:
 
   release-and-build:
     needs: [pre-build]
-    uses: Ultimagen/ugbio-utils/.github/workflows/release-and-build-docker.yml@DATA-9857-release-and-build-docker-workflow
+    uses: Ultimagen/ugbio-utils/.github/workflows/release-and-build-docker.yml@main
     secrets: inherit
     with:
       docker-image: gridss

--- a/.github/workflows/release-gridss-docker.yaml
+++ b/.github/workflows/release-gridss-docker.yaml
@@ -27,7 +27,7 @@ jobs:
 
   release-and-build:
     needs: [pre-build]
-    uses: Ultimagen/ugbio-utils/.github/workflows/release-and-build-docker.yml@main
+    uses: Ultimagen/ugbio-utils/.github/workflows/release-and-build-docker.yml@DATA-9857-release-and-build-docker-workflow
     secrets: inherit
     with:
       docker-image: gridss

--- a/.github/workflows/release-gridss-docker.yaml
+++ b/.github/workflows/release-gridss-docker.yaml
@@ -19,7 +19,14 @@ permissions:
   contents: write
 
 jobs:
+  pre-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/download-docker-resources
+
   release-and-build:
+    needs: [pre-build]
     uses: Ultimagen/ugbio-utils/.github/workflows/release-and-build-docker.yml@main
     secrets: inherit
     with:
@@ -27,3 +34,5 @@ jobs:
       minor-release: ${{ inputs.minor-release }}
       create-release: ${{ inputs.create-release }}
       base-branch: "ilyasoifer/flow.gridss"
+      docker-target: gridss
+      artifact-name: docker-resources


### PR DESCRIPTION
## Summary
Extracts the gridss docker pre-build (GCS resource download + artifact upload) into a composite action `.github/actions/download-docker-resources`, used by **both** `build-gridss-docker.yml` and `release-gridss-docker.yaml`.

Previously the release workflow called the common `release-and-build-docker.yml` directly and skipped the resource download, so released gridss images were missing `RepeatMasker`/`rmblast`. Now the release caller runs the composite action in a `pre-build` job, then the common workflow (with `artifact-name: docker-resources` + `docker-target: gridss`) builds a resource-complete image.

## Files
- **new** `.github/actions/download-docker-resources/action.yml` — composite action
- `.github/workflows/build-gridss-docker.yml` — pre-build now uses the composite action
- `.github/workflows/release-gridss-docker.yaml` — adds `pre-build` job + `artifact-name`/`docker-target`

## Dependency
Requires the ugbio-utils `artifact-name` pass-through change (`release-and-build-docker.yml`) to be merged to `main` first.